### PR TITLE
Batch SMS URL has changed.

### DIFF
--- a/src/anlutro/BulkSms/Sender/Bulk.php
+++ b/src/anlutro/BulkSms/Sender/Bulk.php
@@ -22,7 +22,7 @@ class Bulk
 	 *
 	 * @var string
 	 */
-	protected $url = 'http://bulksms.vsms.net:5567/eapi/submission/send_batch/2/2.0';
+	protected $url = 'http://bulksms.vsms.net:5567/eapi/submission/send_batch/1/1.0';
 
 	/**
 	 * The cURL instance.


### PR DESCRIPTION
New (or old, since they've somehow changed from 2.0 back to 1.0) URL is found at http://bulksms.vsms.net/docs/eapi/submission/send_batch/
